### PR TITLE
Price bug on listing page

### DIFF
--- a/src/models/price/Price.php
+++ b/src/models/price/Price.php
@@ -54,7 +54,7 @@ abstract class Price implements PriceInterface
             }
             self::$_priceMap[$priceClass] = $price;
         } else {
-            $price = self::$_priceMap[$priceClass];
+            $price = clone self::$_priceMap[$priceClass];
         }
 
         /* @var $price Price */


### PR DESCRIPTION
When I get many goods of same type the `price` property overrides the previous value of `Price::_goods`.
Clone construction fixes this bug.