### PR TITLE
Default values for Cart model

### DIFF
--- a/src/models/order/Cart.php
+++ b/src/models/order/Cart.php
@@ -63,6 +63,7 @@ class Cart extends ActiveRecord
             [['context_id', 'currency_iso_code'], 'required'],
             [['context_id', 'is_locked', 'is_retail', 'created_by', 'created_at', 'updated_at', 'user_id'], 'integer'],
             [['items_count', 'total_price_with_discount', 'total_price_without_discount'], 'number'],
+            [['items_count', 'total_price_with_discount', 'total_price_without_discount'], 'default', 'value' => 0],
             [['currency_iso_code'], 'string', 'max' => 3],
             [['packed_json_params'], 'string',],
         ];


### PR DESCRIPTION
When your cart is en empty and you use formatter for displaying a price you can see `$ (not set)` instead of `$ 0`.